### PR TITLE
Fix `undefined method 'in?' for string` bug

### DIFF
--- a/lib/mailjet/campaign.rb
+++ b/lib/mailjet/campaign.rb
@@ -55,7 +55,7 @@ module Mailjet
       def find(*params)
         options = params.last.is_a?(Hash) ? params.pop : {}
         ids = params.flatten.map(&:to_s).reject(&:blank?)
-        self.all(options).find{|c| c.id.to_s.in?(ids)}
+        self.all(options).find{|c| ids.include?(c.id.to_s)}
       end
     end
   end


### PR DESCRIPTION
When trying to find a campaign with `Mailjet::Campaign.find(123)` I'm getting `NoMethodError: undefined method`in?' for "134342":String` - this fixes it for me and the tests still pass (although they were passing before when they maybe should not have been). 
