### PR TITLE
README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Add the keys to an initializer:
 Mailjet.configure do |config|
   config.api_key = 'your-api-key'
   config.secret_key = 'your-secret-key'
-  config.default_from = 'my_regitered_mailjet_email@domain.com'
+  config.default_from = 'my_registered_mailjet_email@domain.com'
 end
 ```
 


### PR DESCRIPTION
Fixed spelling mistake. 

my_regitered_mailjet_email@domain.com -> my_registered_mailjet_email@domain.com
