### PR TITLE
Add a method to set the HTML for a campaign

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ config.action_mailer.delivery_method = :mailjet
 #### Set the raw HTML for a campaign:
 
 ```ruby
-> campaign.set(html: "<html><head><title>Test</title></head><body>Test <a href=\"[[UNSUB_LINK_EN]]\">[[UNSUB_LINK_EN]]</a></body></html>") 
+> campaign.set_html("<html><head><title>Test</title></head><body>Test <a href=\"[[UNSUB_LINK_EN]]\">[[UNSUB_LINK_EN]]</a></body></html>") 
 => OK # response status
 ```
 

--- a/lib/mailjet/campaign.rb
+++ b/lib/mailjet/campaign.rb
@@ -33,9 +33,10 @@ module Mailjet
       (options.delete(:api) || Mailjet::Api.singleton).messageHtmlcampaign(options.reverse_merge(:id => self.id))["html"]
     end
 
-    def set(*params)
-      options = params.last.is_a?(Hash) ? params.pop : {}
-      (options.delete(:api) || Mailjet::Api.singleton).messageSethtmlcampaign(options.reverse_merge(:id => self.id), 'Post')["status"]
+    def set_html(*params)
+      options = params.extract_options!
+      html = params.first
+      (options.delete(:api) || Mailjet::Api.singleton).messageSethtmlcampaign(options.reverse_merge(:id => self.id, :html => html), 'Post')["status"]
     end
 
     def duplicate(options = {})

--- a/test/mailjet/campaign_test.rb
+++ b/test/mailjet/campaign_test.rb
@@ -51,7 +51,7 @@ describe Mailjet::Campaign do
 
     # Mailjet::Campaign#set_html
     html_test = "<html><head><title>Test</title></head><body>Test <a href=\"[[UNSUB_LINK_EN]]\">[[UNSUB_LINK_EN]]</a></body></html>"
-    dup.set(html: html_test).must_equal 'OK'
+    dup.set_html(html_test).must_equal 'OK'
     dup.html.must_equal html_test
 
     sleep 10 # wait for the campaign to be send


### PR DESCRIPTION
According to: https://eu.mailjet.com/docs/api/message/sethtmlcampaign

_Note_: I changed the "dup" campaign html because of "campaign" is sending before my test (and apparently it's impossible to change html for it).
