### PR TITLE
Adding server config

### DIFF
--- a/lib/mailjet/configuration.rb
+++ b/lib/mailjet/configuration.rb
@@ -8,7 +8,8 @@ module Mailjet
     mattr_accessor :use_https
     mattr_accessor :domain
     mattr_accessor :default_from
-    
+    mattr_accessor :server
+
     @@use_https = true
     @@api_version = 0.1
     @@domain = ''

--- a/lib/mailjet/mailer.rb
+++ b/lib/mailjet/mailer.rb
@@ -5,7 +5,7 @@ class Mailjet::Mailer < ::Mail::SMTP
   def initialize options = {}
     ActionMailer::Base.default(:from => Mailjet.config.default_from) if Mailjet.config.default_from.present?
     super({
-      :address  => "in.mailjet.com",
+      :address  => Mailjet.config.server || "in.mailjet.com",
       :port  => 587,
       :authentication  => 'plain',
       :user_name => Mailjet.config.api_key,


### PR DESCRIPTION
Using the mailjet gem, I had a problem where I'd get SMTP auth errors when I tried to send email. Turns out that my Mailjet SMTP info says to use "in-v3.mailjet.com" as the SMTP server instead of "in.mailjet.com". Unfortunately, the latter was hard-coded in the gem. This patch allows it to be configured.
