### PR TITLE
Fix MessageDelivery for ActionMailer

### DIFF
--- a/lib/mailjet/message_delivery.rb
+++ b/lib/mailjet/message_delivery.rb
@@ -3,7 +3,8 @@ require 'mailjet/resource'
 module Mailjet
   class MessageDelivery
     include Mailjet::Resource
-    self.resource_path = 'v3/send'
+    self.resource_path = 'v3/send/message'
     self.public_operations = [:post]
+    self.properties = [:from, :sender, :to, :cc, :bcc, :subject, :text]
   end
 end


### PR DESCRIPTION
- API endpoint was wrong;
- No properties were whitelisted.

There is probably more properties to whitelist, I only whitelisted the common ones.
