### PR TITLE
use alternative syntax to avoid errors with Ruby 2.2

### DIFF
--- a/lib/mailjet/api_error.rb
+++ b/lib/mailjet/api_error.rb
@@ -10,13 +10,13 @@ module Mailjet
       self.code = code
       # code is ugly, output is pretty
       super("error #{code} while sending #{request.inspect} to #{request_path} with #{params.inspect}\n\n" +
-        (res['errors'].present? ?
+        if res['errors'].present?
           [(res['errors'] || [])].flatten.map do |param, text|
             [param, text].map(&:to_s).reject(&:blank?).join(': ')
-          end.join("\n") :
+          end.join("\n")
+        else
           res.inspect
-        ) +
-        "\n\nPlease see http://api.mailjet.com/0.1/HelpStatus for more informations on error numbers.\n\n"
+        end + "\n\nPlease see http://api.mailjet.com/0.1/HelpStatus for more informations on error numbers.\n\n"
       )
     end
   end


### PR DESCRIPTION
Ruby 2.2 seems to have a problem with blocks and the ternary operator.

This ~~stupid~~simple trick should be sufficient.

See https://www.ruby-forum.com/topic/6664839