### PR TITLE
Changed payload hash to rocket syntax for 2.1.x compatibility

### DIFF
--- a/lib/mailjet/mailer.rb
+++ b/lib/mailjet/mailer.rb
@@ -28,24 +28,24 @@ class Mailjet::APIMailer
   def deliver!(mail)
     if mail.multipart?
       content = {
-        text: mail.text_part.try(:decoded),
-        html: mail.html_part.try(:decoded),
-        attachment: mail.attachments.select{ |a| !a.inline? }.try(:decoded),
-        inlineattachment: mail.attachments.select{ |a| !a.inline? }.try(:decoded)
+        :text => mail.text_part.try(:decoded),
+        :html => mail.html_part.try(:decoded),
+        :attachment => mail.attachments.select{ |a| !a.inline? }.try(:decoded),
+        :inlineattachment => mail.attachments.select{ |a| !a.inline? }.try(:decoded)
       }
     else
-      content = (mail.mime_type == "text/html") ? {html: mail.body.decoded} : {text: mail.body.decoded}
+      content = (mail.mime_type == "text/html") ? {:html => mail.body.decoded} : {:text => mail.body.decoded}
     end
 
     payload = {
-      from: mail.from || Mailjet.config.default_from,
-      sender: mail.sender,
-      to: mail.to,
-      cc: mail.cc,
-      bcc: mail.bcc,
-      subject: mail.subject,
-      'mj-customid': mail['X-MJ-CustomID'] && mail['X-MJ-CustomID'].value,
-      'mj-eventpayload': mail['X-MJ-EventPayload'] && mail['X-MJ-EventPayload'].value
+      :from => mail.from || Mailjet.config.default_from,
+      :sender => mail.sender,
+      :to => mail.to,
+      :cc => mail.cc,
+      :bcc => mail.bcc,
+      :subject => mail.subject,
+      :'mj-customid' => mail['X-MJ-CustomID'] && mail['X-MJ-CustomID'].value,
+      :'mj-eventpayload' => mail['X-MJ-EventPayload'] && mail['X-MJ-EventPayload'].value
     }.merge(content).merge(@delivery_method_options)
 
     Mailjet::MessageDelivery.create(payload)


### PR DESCRIPTION
Changed payload hash to rocket syntax for 2.1.x compatibility
Due to issue https://github.com/mailjet/mailjet-gem/issues/43