### PR TITLE
- Fix for using Mailjet::Contact.find when passing email of contact and not his ID

### DIFF
--- a/lib/mailjet/resource.rb
+++ b/lib/mailjet/resource.rb
@@ -71,7 +71,6 @@ module Mailjet
         self.resource_path = create_action_resource_path(id, job_id) if self.action
         #
         attributes = parse_api_json(connection[id].get(default_headers)).first
-		attributes[:id] = id
         instanciate_from_api(attributes)
       rescue Mailjet::ApiError => e
         if e.code == 404


### PR DESCRIPTION
As stated by Mallet API reference, it is possible to query /contact with email of contact as it is unique key.
Btw, then using Mailjet::Contact.find, id attribute, received from API response, has overridden by passed value, which is not good if you want, for example, obtain user ID knowing only his mail.