### PR TITLE
Bug Fix: default_from overriding `from` in emails sent via APIMailer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 
 rvm:
-  - 2.2.3
+  - 2.2.5
 script:
   - bundle exec rspec spec/mailjet/mailer_spec.rb spec/mailjet-spec.rb

--- a/lib/mailjet/mailer.rb
+++ b/lib/mailjet/mailer.rb
@@ -82,8 +82,7 @@ class Mailjet::APIMailer
     content[:headers]['Reply-To'] = mail.reply_to.join(', ') if mail.reply_to
 
     # Mailjet Send API does not support full from. Splitting the from field into two: name and email address
-    if Mailjet.config.default_from.present?
-      # from_address = Mail::AddressList.new(Mailjet.config.default_from).addresses[0]
+    if mail[:from].nil? && Mailjet.config.default_from.present?
       mail[:from] = Mailjet.config.default_from
     end
 

--- a/spec/mailjet/mailer_spec.rb
+++ b/spec/mailjet/mailer_spec.rb
@@ -1,4 +1,3 @@
-
 require 'base64'
 require 'mailjet'
 require 'mailjet/mailer'
@@ -26,6 +25,49 @@ module Mailjet
           from_name: fromName,
           from_email: fromEmail,
           text_part: text
+        )
+      )
+
+      APIMailer.new.deliver!(message)
+    end
+
+    it 'fallsback to default_from if from is not set' do
+      Mailjet.config.default_from = 'Test Person <test@example.com>'
+
+      message = Mail.new
+      message.text_part = Mail::Part.new do
+        body 'test'
+      end
+
+      message.to = ['foo@bar.com']
+
+      expect(Mailjet::Send).to receive(:create).with(
+        hash_including(
+          from_name: 'Test Person',
+          from_email: 'test@example.com',
+          text_part: 'test'
+        )
+      )
+
+      APIMailer.new.deliver!(message)
+    end
+
+    it 'does not overrwrite `from` with `default_from`' do
+      Mailjet.config.default_from = 'Test Person <test@example.com>'
+
+      message = Mail.new
+      message.text_part = Mail::Part.new do
+        body 'test'
+      end
+
+      message.to = ['foo@bar.com']
+      message.from = 'FooBar <foobar@mailjet.com>'
+
+      expect(Mailjet::Send).to receive(:create).with(
+        hash_including(
+          from_name: 'FooBar',
+          from_email: 'foobar@mailjet.com',
+          text_part: 'test'
         )
       )
 


### PR DESCRIPTION
Hi,

Small bug fix I noticed earlier today. 😄 

When using the APIMailer with ActionMailer.

If you have `default_from` set, but then try to send an email with a different `from` address. It currently ignores the `from` and always uses the default value.

Making it impossible to send email from an address other than the `default_from`.

This change checks to see if `from` is set before using the value set in `default_from`.

Thanks