### PR TITLE
Error reason

### DIFF
--- a/lib/mailjet/api_error.rb
+++ b/lib/mailjet/api_error.rb
@@ -4,10 +4,13 @@ require 'active_support'
 module Mailjet
   class ApiError < StandardError
 
-    attr_accessor :code
+    attr_accessor :code, :reason
+
 
     def initialize(code, res, request, request_path, params)
       self.code = code
+      resdec = ActiveSupport::JSON.decode(res)
+      self.reason = resdec['ErrorMessage']
       # code is ugly, output is pretty
       super("error #{code} while sending #{request.inspect} to #{request_path} with #{params.inspect}\n\n" +
         if res['errors'].present?

--- a/lib/mailjet/api_error.rb
+++ b/lib/mailjet/api_error.rb
@@ -16,7 +16,7 @@ module Mailjet
           end.join("\n")
         else
           res.inspect
-        end + "\n\nPlease see http://api.mailjet.com/0.1/HelpStatus for more informations on error numbers.\n\n"
+        end + "\n\nPlease see https://dev.mailjet.com/guides/#status-codes for more informations on error numbers.\n\n"
       )
     end
   end

--- a/lib/mailjet/resources/campaigndraft.rb
+++ b/lib/mailjet/resources/campaigndraft.rb
@@ -1,0 +1,12 @@
+require 'mailjet/resource'
+
+module Mailjet
+  class Campaigndraft
+    include Mailjet::Resource
+    self.resource_path = 'v3/REST/campaigndraft'
+    self.public_operations = [:get, :put, :post]
+    self.filters = [:campaign, :contacts_list, :delivered_at, :edit_mode, :is_archived, :is_campaign, :is_deleted, :is_handled, :is_starred, :modified, :news_letter_template, :segmentation, :status, :subject, :template]
+    self.resourceprop = [:campaign, :contacts_list, :created_at, :delivered_at, :edit_mode, :id, :is_starred, :is_text_part_included, :locale, :modified_at, :preset, :reply_email, :segmentation, :sender, :sender_email, :sender_name, :status, :subject, :template_id, :title, :url, :used, 'CampaignID', 'CampaignALT', 'ContactsListID', 'ContactsListALT', 'SegmentationID', 'SegmentationALT', :contacts_list_id,'TemplateID']
+
+  end
+end

--- a/lib/mailjet/resources/campaigndraft_detailcontent.rb
+++ b/lib/mailjet/resources/campaigndraft_detailcontent.rb
@@ -1,0 +1,13 @@
+require 'mailjet/resource'
+
+module Mailjet
+  class Campaigndraft_detailcontent
+    include Mailjet::Resource
+    self.action = "detailcontent"
+    self.resource_path = "v3/REST/campaigndraft/id/#{self.action}"
+    self.public_operations = [:get, :post]
+    self.filters = []
+    self.resourceprop = [:text_part, :html_part, :headers, :mjml_content]
+
+  end
+end

--- a/lib/mailjet/resources/campaigndraft_schedule.rb
+++ b/lib/mailjet/resources/campaigndraft_schedule.rb
@@ -1,0 +1,13 @@
+require 'mailjet/resource'
+
+module Mailjet
+  class Campaigndraft_schedule
+    include Mailjet::Resource
+    self.action = "schedule"
+    self.resource_path = "v3/REST/campaigndraft/id/#{self.action}"
+    self.public_operations = [:post, :delete , :get]
+    self.filters = []
+    self.resourceprop = [:date]
+    
+  end
+end

--- a/lib/mailjet/resources/campaigndraft_send.rb
+++ b/lib/mailjet/resources/campaigndraft_send.rb
@@ -1,0 +1,12 @@
+require 'mailjet/resource'
+
+module Mailjet
+  class Campaigndraft_send
+    include Mailjet::Resource
+    self.action = "send"
+    self.resource_path = "v3/REST/campaigndraft/id/#{self.action}"
+    self.public_operations = [:post]
+    self.filters = []
+    self.resourceprop = []
+  end
+end

--- a/lib/mailjet/resources/campaigndraft_status.rb
+++ b/lib/mailjet/resources/campaigndraft_status.rb
@@ -1,0 +1,13 @@
+require 'mailjet/resource'
+
+module Mailjet
+  class Campaigndraft_status
+    include Mailjet::Resource
+    self.action = 'status'
+    self.resource_path = "v3/REST/campaigndraft/id/#{self.action}"
+    self.public_operations =  [:get]
+    self.filters = []
+    self.resourceprop = []
+
+  end
+end

--- a/lib/mailjet/resources/campaigndraft_test.rb
+++ b/lib/mailjet/resources/campaigndraft_test.rb
@@ -1,0 +1,13 @@
+require 'mailjet/resource'
+
+module Mailjet
+  class Campaigndraft_test
+    include Mailjet::Resource
+    self.action = "test"
+    self.resource_path = "v3/REST/campaigndraft/id/#{self.action}"
+    self.public_operations = [:post]
+    self.filters = []
+    self.resourceprop = [:email, :name]
+
+  end
+end


### PR DESCRIPTION
Would allow to acces more easily the erro reason 

For example : 

```
begin 
	variable = Mailjet::Campaigndraft_send.create(id: 3585077)
	pp variable
rescue Mailjet::ApiError => e
    p "error : #{e.code} , reason : #{e.reason}"
end
```

would give this 

"error : 400 , reason : Newsletter has to be in status draft or programmed"

if the campaignDraft has already been sent 