### PR TITLE
Codebase cleaning

### DIFF
--- a/lib/mailjet/message_delivery.rb
+++ b/lib/mailjet/message_delivery.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class MessageDelivery
     include Mailjet::Resource

--- a/lib/mailjet/resource.rb
+++ b/lib/mailjet/resource.rb
@@ -1,5 +1,4 @@
 require 'mailjet/connection'
-require 'mailjet/resource'
 require 'active_support/hash_with_indifferent_access'
 require 'active_support/core_ext/class'
 require 'active_support/core_ext/hash'

--- a/lib/mailjet/resources/aggregategraphstatistics.rb
+++ b/lib/mailjet/resources/aggregategraphstatistics.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Aggregategraphstatistics
     include Mailjet::Resource

--- a/lib/mailjet/resources/apikey.rb
+++ b/lib/mailjet/resources/apikey.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Apikey
     include Mailjet::Resource

--- a/lib/mailjet/resources/apikeyaccess.rb
+++ b/lib/mailjet/resources/apikeyaccess.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Apikeyaccess
     include Mailjet::Resource

--- a/lib/mailjet/resources/apikeytotals.rb
+++ b/lib/mailjet/resources/apikeytotals.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Apikeytotals
     include Mailjet::Resource

--- a/lib/mailjet/resources/apitoken.rb
+++ b/lib/mailjet/resources/apitoken.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Apitoken
     include Mailjet::Resource

--- a/lib/mailjet/resources/axtesting.rb
+++ b/lib/mailjet/resources/axtesting.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Axtesting
     include Mailjet::Resource

--- a/lib/mailjet/resources/batchjob.rb
+++ b/lib/mailjet/resources/batchjob.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Batchjob
     include Mailjet::Resource

--- a/lib/mailjet/resources/bouncestatistics.rb
+++ b/lib/mailjet/resources/bouncestatistics.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Bouncestatistics
     include Mailjet::Resource

--- a/lib/mailjet/resources/campaign.rb
+++ b/lib/mailjet/resources/campaign.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Campaign
     include Mailjet::Resource

--- a/lib/mailjet/resources/campaignaggregate.rb
+++ b/lib/mailjet/resources/campaignaggregate.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Campaignaggregate
     include Mailjet::Resource

--- a/lib/mailjet/resources/campaigndraft.rb
+++ b/lib/mailjet/resources/campaigndraft.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Campaigndraft
     include Mailjet::Resource

--- a/lib/mailjet/resources/campaigndraft_detailcontent.rb
+++ b/lib/mailjet/resources/campaigndraft_detailcontent.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Campaigndraft_detailcontent
     include Mailjet::Resource

--- a/lib/mailjet/resources/campaigndraft_schedule.rb
+++ b/lib/mailjet/resources/campaigndraft_schedule.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Campaigndraft_schedule
     include Mailjet::Resource
@@ -8,6 +6,6 @@ module Mailjet
     self.public_operations = [:post, :delete , :get]
     self.filters = []
     self.resourceprop = [:date]
-    
+
   end
 end

--- a/lib/mailjet/resources/campaigndraft_send.rb
+++ b/lib/mailjet/resources/campaigndraft_send.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Campaigndraft_send
     include Mailjet::Resource

--- a/lib/mailjet/resources/campaigndraft_status.rb
+++ b/lib/mailjet/resources/campaigndraft_status.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Campaigndraft_status
     include Mailjet::Resource

--- a/lib/mailjet/resources/campaigndraft_test.rb
+++ b/lib/mailjet/resources/campaigndraft_test.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Campaigndraft_test
     include Mailjet::Resource

--- a/lib/mailjet/resources/campaigngraphstatistics.rb
+++ b/lib/mailjet/resources/campaigngraphstatistics.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Campaigngraphstatistics
     include Mailjet::Resource

--- a/lib/mailjet/resources/campaignoverview.rb
+++ b/lib/mailjet/resources/campaignoverview.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Campaignoverview
     include Mailjet::Resource

--- a/lib/mailjet/resources/campaignstatistics.rb
+++ b/lib/mailjet/resources/campaignstatistics.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Campaignstatistics
     include Mailjet::Resource

--- a/lib/mailjet/resources/clickstatistics.rb
+++ b/lib/mailjet/resources/clickstatistics.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Clickstatistics
     include Mailjet::Resource

--- a/lib/mailjet/resources/contact.rb
+++ b/lib/mailjet/resources/contact.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Contact
     include Mailjet::Resource

--- a/lib/mailjet/resources/contact_getcontactslists.rb
+++ b/lib/mailjet/resources/contact_getcontactslists.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Contact_getcontactslists
     include Mailjet::Resource

--- a/lib/mailjet/resources/contact_managecontactslists.rb
+++ b/lib/mailjet/resources/contact_managecontactslists.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Contact_managecontactslists
     include Mailjet::Resource

--- a/lib/mailjet/resources/contact_managemanycontacts.rb
+++ b/lib/mailjet/resources/contact_managemanycontacts.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Contact_managemanycontacts
     include Mailjet::Resource

--- a/lib/mailjet/resources/contactdata.rb
+++ b/lib/mailjet/resources/contactdata.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Contactdata
     include Mailjet::Resource

--- a/lib/mailjet/resources/contactfilter.rb
+++ b/lib/mailjet/resources/contactfilter.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Contactfilter
     include Mailjet::Resource

--- a/lib/mailjet/resources/contacthistorydata.rb
+++ b/lib/mailjet/resources/contacthistorydata.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Contacthistorydata
     include Mailjet::Resource

--- a/lib/mailjet/resources/contactmetadata.rb
+++ b/lib/mailjet/resources/contactmetadata.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Contactmetadata
     include Mailjet::Resource

--- a/lib/mailjet/resources/contactslist.rb
+++ b/lib/mailjet/resources/contactslist.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Contactslist
     include Mailjet::Resource

--- a/lib/mailjet/resources/contactslist_managecontact.rb
+++ b/lib/mailjet/resources/contactslist_managecontact.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Contactslist_managecontact
     include Mailjet::Resource

--- a/lib/mailjet/resources/contactslist_managemanycontacts.rb
+++ b/lib/mailjet/resources/contactslist_managemanycontacts.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Contactslist_managemanycontacts
     include Mailjet::Resource

--- a/lib/mailjet/resources/contactslistsignup.rb
+++ b/lib/mailjet/resources/contactslistsignup.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Contactslistsignup
     include Mailjet::Resource

--- a/lib/mailjet/resources/contactstatistics.rb
+++ b/lib/mailjet/resources/contactstatistics.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Contactstatistics
     include Mailjet::Resource

--- a/lib/mailjet/resources/csvimport.rb
+++ b/lib/mailjet/resources/csvimport.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Csvimport
     include Mailjet::Resource

--- a/lib/mailjet/resources/dns.rb
+++ b/lib/mailjet/resources/dns.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class DNS
     include Mailjet::Resource

--- a/lib/mailjet/resources/dns_check.rb
+++ b/lib/mailjet/resources/dns_check.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class DNS_check
     include Mailjet::Resource

--- a/lib/mailjet/resources/domainstatistics.rb
+++ b/lib/mailjet/resources/domainstatistics.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Domainstatistics
     include Mailjet::Resource

--- a/lib/mailjet/resources/eventcallbackurl.rb
+++ b/lib/mailjet/resources/eventcallbackurl.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Eventcallbackurl
     include Mailjet::Resource

--- a/lib/mailjet/resources/geostatistics.rb
+++ b/lib/mailjet/resources/geostatistics.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Geostatistics
     include Mailjet::Resource

--- a/lib/mailjet/resources/graphstatistics.rb
+++ b/lib/mailjet/resources/graphstatistics.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Graphstatistics
     include Mailjet::Resource

--- a/lib/mailjet/resources/listrecipient.rb
+++ b/lib/mailjet/resources/listrecipient.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Listrecipient
     include Mailjet::Resource

--- a/lib/mailjet/resources/listrecipientstatistics.rb
+++ b/lib/mailjet/resources/listrecipientstatistics.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Listrecipientstatistics
     include Mailjet::Resource

--- a/lib/mailjet/resources/liststatistics.rb
+++ b/lib/mailjet/resources/liststatistics.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Liststatistics
     include Mailjet::Resource

--- a/lib/mailjet/resources/manycontacts.rb
+++ b/lib/mailjet/resources/manycontacts.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Manycontacts
     include Mailjet::Resource

--- a/lib/mailjet/resources/message.rb
+++ b/lib/mailjet/resources/message.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Message
     include Mailjet::Resource

--- a/lib/mailjet/resources/messagehistory.rb
+++ b/lib/mailjet/resources/messagehistory.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Messagehistory
     include Mailjet::Resource

--- a/lib/mailjet/resources/messageinformation.rb
+++ b/lib/mailjet/resources/messageinformation.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Messageinformation
     include Mailjet::Resource

--- a/lib/mailjet/resources/messagesentstatistics.rb
+++ b/lib/mailjet/resources/messagesentstatistics.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Messagesentstatistics
     include Mailjet::Resource

--- a/lib/mailjet/resources/messagestate.rb
+++ b/lib/mailjet/resources/messagestate.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Messagestate
     include Mailjet::Resource

--- a/lib/mailjet/resources/messagestatistics.rb
+++ b/lib/mailjet/resources/messagestatistics.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Messagestatistics
     include Mailjet::Resource

--- a/lib/mailjet/resources/metadata.rb
+++ b/lib/mailjet/resources/metadata.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Metadata
     include Mailjet::Resource

--- a/lib/mailjet/resources/metasender.rb
+++ b/lib/mailjet/resources/metasender.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Metasender
     include Mailjet::Resource

--- a/lib/mailjet/resources/myprofile.rb
+++ b/lib/mailjet/resources/myprofile.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Myprofile
     include Mailjet::Resource

--- a/lib/mailjet/resources/newsletter.rb
+++ b/lib/mailjet/resources/newsletter.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Newsletter
     include Mailjet::Resource

--- a/lib/mailjet/resources/newsletter_detailcontent.rb
+++ b/lib/mailjet/resources/newsletter_detailcontent.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Newsletter_detailcontent
     include Mailjet::Resource

--- a/lib/mailjet/resources/newsletter_schedule.rb
+++ b/lib/mailjet/resources/newsletter_schedule.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Newsletter_schedule
     include Mailjet::Resource
@@ -8,6 +6,6 @@ module Mailjet
     self.public_operations = [:post, :delete]
     self.filters = []
     self.resourceprop = [:date]
-    
+
   end
 end

--- a/lib/mailjet/resources/newsletter_send.rb
+++ b/lib/mailjet/resources/newsletter_send.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Newsletter_send
     include Mailjet::Resource

--- a/lib/mailjet/resources/newsletter_status.rb
+++ b/lib/mailjet/resources/newsletter_status.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Newsletter_status
     include Mailjet::Resource

--- a/lib/mailjet/resources/newsletter_test.rb
+++ b/lib/mailjet/resources/newsletter_test.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Newsletter_test
     include Mailjet::Resource

--- a/lib/mailjet/resources/newsletterblock.rb
+++ b/lib/mailjet/resources/newsletterblock.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Newsletterblock
     include Mailjet::Resource

--- a/lib/mailjet/resources/newsletterproperties.rb
+++ b/lib/mailjet/resources/newsletterproperties.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Newsletterproperties
     include Mailjet::Resource

--- a/lib/mailjet/resources/newslettertemplate.rb
+++ b/lib/mailjet/resources/newslettertemplate.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Newslettertemplate
     include Mailjet::Resource

--- a/lib/mailjet/resources/newslettertemplateblock.rb
+++ b/lib/mailjet/resources/newslettertemplateblock.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Newslettertemplateblock
     include Mailjet::Resource

--- a/lib/mailjet/resources/newslettertemplatecategory.rb
+++ b/lib/mailjet/resources/newslettertemplatecategory.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Newslettertemplatecategory
     include Mailjet::Resource

--- a/lib/mailjet/resources/newslettertemplateproperties.rb
+++ b/lib/mailjet/resources/newslettertemplateproperties.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Newslettertemplateproperties
     include Mailjet::Resource

--- a/lib/mailjet/resources/openinformation.rb
+++ b/lib/mailjet/resources/openinformation.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Openinformation
     include Mailjet::Resource

--- a/lib/mailjet/resources/openstatistics.rb
+++ b/lib/mailjet/resources/openstatistics.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Openstatistics
     include Mailjet::Resource

--- a/lib/mailjet/resources/parseroute.rb
+++ b/lib/mailjet/resources/parseroute.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Parseroute
     include Mailjet::Resource

--- a/lib/mailjet/resources/preferences.rb
+++ b/lib/mailjet/resources/preferences.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Preferences
     include Mailjet::Resource

--- a/lib/mailjet/resources/send.rb
+++ b/lib/mailjet/resources/send.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Send
     include Mailjet::Resource

--- a/lib/mailjet/resources/sender.rb
+++ b/lib/mailjet/resources/sender.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Sender
     include Mailjet::Resource

--- a/lib/mailjet/resources/sender_validate.rb
+++ b/lib/mailjet/resources/sender_validate.rb
@@ -1,6 +1,3 @@
-
-require 'mailjet/resource'
-
 module Mailjet
   class Sender_validate
     include Mailjet::Resource

--- a/lib/mailjet/resources/senderstatistics.rb
+++ b/lib/mailjet/resources/senderstatistics.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Senderstatistics
     include Mailjet::Resource

--- a/lib/mailjet/resources/template.rb
+++ b/lib/mailjet/resources/template.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Template
     include Mailjet::Resource

--- a/lib/mailjet/resources/template_detailcontent.rb
+++ b/lib/mailjet/resources/template_detailcontent.rb
@@ -1,6 +1,3 @@
-
-require 'mailjet/resource'
-
 module Mailjet
   class Template_detailcontent
     include Mailjet::Resource

--- a/lib/mailjet/resources/toplinkclicked.rb
+++ b/lib/mailjet/resources/toplinkclicked.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Toplinkclicked
     include Mailjet::Resource

--- a/lib/mailjet/resources/trigger.rb
+++ b/lib/mailjet/resources/trigger.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Trigger
     include Mailjet::Resource

--- a/lib/mailjet/resources/user.rb
+++ b/lib/mailjet/resources/user.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class User
     include Mailjet::Resource

--- a/lib/mailjet/resources/useragentstatistics.rb
+++ b/lib/mailjet/resources/useragentstatistics.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Useragentstatistics
     include Mailjet::Resource

--- a/lib/mailjet/resources/widget.rb
+++ b/lib/mailjet/resources/widget.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Widget
     include Mailjet::Resource

--- a/lib/mailjet/resources/widgetcustomvalue.rb
+++ b/lib/mailjet/resources/widgetcustomvalue.rb
@@ -1,5 +1,3 @@
-require 'mailjet/resource'
-
 module Mailjet
   class Widgetcustomvalue
     include Mailjet::Resource

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,6 @@ require 'minitest/pride'
 require 'minitest-spec-context'
 require 'mocha/setup'
 require 'mailjet'
-require 'mailjet/resource'
 require 'turn/autorun'
 
 require File.expand_path './support/vcr_setup.rb', __dir__


### PR DESCRIPTION
- remove useless `require 'mailjet/resource'` occurrences:
  [`lib/mailjet.rb`](https://github.com/mailjet/mailjet-gem/blob/master/lib/mailjet.rb#L7) only is responsible for requiring [`lib/mailjet/resource.rb`](https://github.com/mailjet/mailjet-gem/blob/master/lib/mailjet/resource.rb)