### PR TITLE
Ability to configure credentials at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,10 +139,25 @@ Or if you prefer sending messages through [Mailjet Send API](http://dev.mailjet.
 config.action_mailer.delivery_method = :mailjet_api
 ```
 
-You can use mailjet specific options with `delivery_method_options` as detailed in the official [ActionMailer doc][http://guides.rubyonrails.org/action_mailer_basics.html#sending-emails-with-dynamic-delivery-options].
+You can use mailjet specific options with `delivery_method_options` as detailed in the official [ActionMailer doc](http://guides.rubyonrails.org/action_mailer_basics.html#sending-emails-with-dynamic-delivery-options):
+
+```ruby
+class AwesomeMailer < ApplicationMailer
+
+  def awesome_mail(user)
+
+    mail(
+      to: user.email,
+      delivery_method_options: { api_key: 'your-api-key', secret_key: 'your-secret-key' }
+    )
+  end
+end
+```
 
 Supported options are:
 ```ruby
+* :api_key
+* :secret_key
 * :'mj-prio'
 * :'mj-campaign'
 * :'mj-deduplicatecampaign'

--- a/lib/mailjet/mailer.rb
+++ b/lib/mailjet/mailer.rb
@@ -12,8 +12,8 @@ class Mailjet::Mailer < ::Mail::SMTP
       address: 'in-v3.mailjet.com',
       port: 587,
       authentication: 'plain',
-      user_name: Mailjet.config.api_key,
-      password: Mailjet.config.secret_key,
+      user_name: options.delete(:api_key) || Mailjet.config.api_key,
+      password: options.delete(:secret_key) || Mailjet.config.secret_key,
       enable_starttls_auto: true
     }.merge(options))
   end
@@ -28,6 +28,7 @@ ActionMailer::Base.add_delivery_method :mailjet, Mailjet::Mailer
 class Mailjet::APIMailer
   def initialize(options = {})
     @delivery_method_options = options.slice(
+      :api_key, :secret_key,
       :recipients, :'mj-prio', :'mj-campaign', :'mj-deduplicatecampaign',
       :'mj-templatelanguage', :'mj-templateerrorreporting', :'mj-templateerrordeliver', :'mj-templateid',
       :'mj-trackopen', :'mj-trackclick',


### PR DESCRIPTION
Override dynamically credentials at runtime using `:delivery_method_options` and passing `{ api_key: 'your-api-key', secret_key: 'your-secret-key' }` at instance level