### PR TITLE
Syntax + allow GET Newsletter Schedule

### DIFF
--- a/lib/mailjet/connection.rb
+++ b/lib/mailjet/connection.rb
@@ -69,7 +69,7 @@ module Mailjet
           @adapter.send(method, formatted_payload, additional_headers, &block)
         end
       else
-        return {'Count': 0, 'Data': [mock_api_call: true], 'Total': 0}.to_json
+        return {'Count' => 0, 'Data' => [mock_api_call: true], 'Total' => 0}.to_json
       end
     rescue RestClient::Exception => e
       handle_exception(e, additional_headers, formatted_payload)

--- a/lib/mailjet/resources/newsletter_schedule.rb
+++ b/lib/mailjet/resources/newsletter_schedule.rb
@@ -3,7 +3,7 @@ module Mailjet
     include Mailjet::Resource
     self.action = "schedule"
     self.resource_path = "REST/newsletter/id/#{self.action}"
-    self.public_operations = [:post, :delete]
+    self.public_operations = [:get, :post, :delete]
     self.filters = []
     self.resourceprop = [:date]
 


### PR DESCRIPTION
Breaking syntax for RAILS <4

Allow GET request to be made to the API for newsletter schedule. Right now there is no way to fetch the programmed date of a newsletter.