### PR TITLE
fix options forwarding from APIMailer to Mailjet::Send

### DIFF
--- a/lib/mailjet/mailer.rb
+++ b/lib/mailjet/mailer.rb
@@ -26,26 +26,29 @@ ActionMailer::Base.add_delivery_method :mailjet, Mailjet::Mailer
 # Mailjet sends API expects a JSON payload as the input.
 # The deliver methods maps the Mail::Message attributes to the MailjetSend API JSON expected structure
 class Mailjet::APIMailer
+  V3_0_PERMITTED_OPTIONS = [
+    :recipients, :'mj-prio', :'mj-campaign', :'mj-deduplicatecampaign',
+    :'mj-templatelanguage', :'mj-templateerrorreporting', :'mj-templateerrordeliver', :'mj-templateid',
+    :'mj-trackopen', :'mj-trackclick',
+    :'mj-customid', :'mj-eventpayload', :vars, :headers,
+  ]
+
+  V3_1_PERMITTED_OPTIONS = [
+    :'Priority', :'CustomCampaign', :'DeduplicateCampaign',
+    :'TemplateLanguage', :'TemplateErrorReporting', :'TemplateErrorDeliver', :'TemplateID',
+    :'TrackOpens', :'TrackClicks',
+    :'CustomID', :'EventPayload', :'Variables', :'Headers',
+  ]
+
+  CONNECTION_PERMITTED_OPTIONS = [:api_key, :secret_key]
+
   def initialize(opts = {})
     options = HashWithIndifferentAccess.new(opts)
 
     @version = options[:version]
-
-    @delivery_method_options_v3_0 = options.slice(
-      :recipients, :'mj-prio', :'mj-campaign', :'mj-deduplicatecampaign',
-      :'mj-templatelanguage', :'mj-templateerrorreporting', :'mj-templateerrordeliver', :'mj-templateid',
-      :'mj-trackopen', :'mj-trackclick',
-      :'mj-customid', :'mj-eventpayload', :vars, :headers,
-    )
-
-    @delivery_method_options_v3_1 = options.slice(
-      :'Priority', :'CustomCampaign', :'DeduplicateCampaign',
-      :'TemplateLanguage', :'TemplateErrorReporting', :'TemplateErrorDeliver', :'TemplateID',
-      :'TrackOpens', :'TrackClicks',
-      :'CustomID', :'EventPayload', :'Variables', :'Headers',
-    )
-
-    @connection_options = options.slice(:api_key, :secret_key)
+    @delivery_method_options_v3_0 = options.slice(*V3_0_PERMITTED_OPTIONS)
+    @delivery_method_options_v3_1 = options.slice(*V3_1_PERMITTED_OPTIONS)
+    @connection_options = options.slice(*CONNECTION_PERMITTED_OPTIONS)
   end
 
   def deliver!(mail, opts = {})

--- a/lib/mailjet/mailer.rb
+++ b/lib/mailjet/mailer.rb
@@ -57,10 +57,13 @@ class Mailjet::APIMailer
     # add `@connection_options` in `options` only if not exist yet (values in `options` prime)
     options.reverse_merge!(@connection_options)
 
-    # `options[:version]` primes on attribute, both of them on global config
-    options[:version] ||= (@version || Mailjet.config.api_version)
+    # add `@version` in options if set
+    options[:version] = @version if @version
 
-    if (options[:version] == 'v3.1')
+    # `options[:version]` primes on global config
+    version = options[:version] || Mailjet.config.api_version
+
+    if (version == 'v3.1')
       Mailjet::Send.create({ :Messages => [setContentV3_1(mail)] }, options)
     else
       Mailjet::Send.create(setContentV3_0(mail), options)


### PR DESCRIPTION
[This line](https://github.com/mailjet/mailjet-gem/commit/886a46a09d8aaffe16fba4aa0c53451942cd027f#diff-56c522eb9dd34805bda4061d165bae4dR249) broke options forwarding from `Mailjet::Send#create` to `Mailjet::Send#connection` because [`Mailjet::Send#change_resource_path`](https://github.com/mailjet/mailjet-gem/blob/886a46a09d8aaffe16fba4aa0c53451942cd027f/lib/mailjet/resource.rb#L214-L228) does not forward them

In the meantime, light refacto of [Mailjet::APIMailer#initialize](https://github.com/mailjet/mailjet-gem/blob/886a46a09d8aaffe16fba4aa0c53451942cd027f/lib/mailjet/resource.rb) and [Mailjet::APIMailer#deliver!](https://github.com/mailjet/mailjet-gem/blob/886a46a09d8aaffe16fba4aa0c53451942cd027f/lib/mailjet/mailer.rb#L52-L73)

Tested against Rails app with API v3.0 and v3.1: mails are sent with correct credentials and fail when invalid ones are provided (*i.e.* if you pass your credentials in the conventional way of using Mail: `mail(to: to_address, from: from_address, subject: subject, delivery_method_options: { api_key: 'your-api-key', secret_key: 'your-secret-key' })`)