### PR TITLE
Timeout feature

### DIFF
--- a/lib/mailjet/connection.rb
+++ b/lib/mailjet/connection.rb
@@ -6,7 +6,7 @@ require 'json'
 module Mailjet
   class Connection
 
-    attr_accessor :adapter, :public_operations, :read_only, :perform_api_call, :read_timeout
+    attr_accessor :adapter, :public_operations, :read_only, :perform_api_call, :read_timeout, :open_timeout
     alias :read_only? :read_only
 
     delegate :options, :concat_urls, :url, to: :adapter
@@ -36,8 +36,9 @@ module Mailjet
       self.public_operations = options[:public_operations] || []
       self.read_only = options[:read_only]
       self.read_timeout = options[:read_timeout]
+      self.open_timeout = options[:open_timeout]
       # self.adapter = adapter_class.new(end_point, options.merge(user: api_key, password: secret_key, :verify_ssl => false, content_type: 'application/json'))
-      self.adapter = adapter_class.new(end_point, options.merge(user: api_key, password: secret_key, content_type: 'application/json', read_timeout: self.read_timeout))
+      self.adapter = adapter_class.new(end_point, options.merge(user: api_key, password: secret_key, content_type: 'application/json', read_timeout: self.read_timeout, open_timeout: self.open_timeout))
       self.perform_api_call = options.key?(:perform_api_call) ? options[:perform_api_call] : true
     end
 

--- a/lib/mailjet/connection.rb
+++ b/lib/mailjet/connection.rb
@@ -6,7 +6,7 @@ require 'json'
 module Mailjet
   class Connection
 
-    attr_accessor :adapter, :public_operations, :read_only, :perform_api_call
+    attr_accessor :adapter, :public_operations, :read_only, :perform_api_call, :read_timeout
     alias :read_only? :read_only
 
     delegate :options, :concat_urls, :url, to: :adapter
@@ -35,8 +35,9 @@ module Mailjet
       adapter_class = options[:adapter_class] || RestClient::Resource
       self.public_operations = options[:public_operations] || []
       self.read_only = options[:read_only]
+      self.read_timeout = options[:read_timeout]
       # self.adapter = adapter_class.new(end_point, options.merge(user: api_key, password: secret_key, :verify_ssl => false, content_type: 'application/json'))
-      self.adapter = adapter_class.new(end_point, options.merge(user: api_key, password: secret_key, content_type: 'application/json'))
+      self.adapter = adapter_class.new(end_point, options.merge(user: api_key, password: secret_key, content_type: 'application/json', read_timeout: self.read_timeout))
       self.perform_api_call = options.key?(:perform_api_call) ? options[:perform_api_call] : true
     end
 

--- a/lib/mailjet/resource.rb
+++ b/lib/mailjet/resource.rb
@@ -40,7 +40,8 @@ module Mailjet
           options[:secret_key] || Mailjet.config.secret_key,
           public_operations: public_operations,
           read_only: read_only,
-          perform_api_call: options[:perform_api_call])
+          perform_api_call: options[:perform_api_call],
+          read_timeout: options[:read_timeout])
       end
 
       def self.default_headers

--- a/lib/mailjet/resource.rb
+++ b/lib/mailjet/resource.rb
@@ -21,7 +21,7 @@ module Mailjet
     extend ActiveSupport::Concern
 
     # define here available options for filtering
-    OPTIONS = [:version, :url, :perform_api_call, :api_key, :secret_key]
+    OPTIONS = [:version, :url, :perform_api_call, :api_key, :secret_key, :read_timeout]
 
     NON_JSON_URLS = ['v3/send/message'] # urls that don't accept JSON input
 

--- a/lib/mailjet/resource.rb
+++ b/lib/mailjet/resource.rb
@@ -21,7 +21,7 @@ module Mailjet
     extend ActiveSupport::Concern
 
     # define here available options for filtering
-    OPTIONS = [:version, :url, :perform_api_call, :api_key, :secret_key, :read_timeout]
+    OPTIONS = [:version, :url, :perform_api_call, :api_key, :secret_key, :read_timeout, :open_timeout]
 
     NON_JSON_URLS = ['v3/send/message'] # urls that don't accept JSON input
 
@@ -41,6 +41,7 @@ module Mailjet
           public_operations: public_operations,
           read_only: read_only,
           perform_api_call: options[:perform_api_call],
+          open_timeout: options[:open_timeout],
           read_timeout: options[:read_timeout])
       end
 


### PR DESCRIPTION
With the following small change users will be able to specify the read_timeout. For example
require 'mailjet'

```
module RubyTest
  # initializers/mailjet.rb
Mailjet.configure do |config|
  config.api_key = '[ENTER]'
  config.secret_key = '[ENTER]'
  config.default_from = '[ENTER]'
end
sender=Mailjet::Send;
#sender.default_connection({perform_api_call:false});
sender.create(
  {
        from_email: "[ENTER]",
        from_name: "Mailjet Pilot",
        subject: "Your email flight plan!",
        text_part: "Dear passenger, welcome to Mailjet! May the delivery force be with you!",
        html_part: "<h3>Dear passenger, welcome to Mailjet!</h3><br />May the delivery force be with you!",
        recipients: [{ 'Email'=> '[ENTER]'}]
  },
    read_timeout:1
           )
end
```