### PR TITLE
FIX broken formatted_payload

### DIFF
--- a/lib/mailjet/resource.rb
+++ b/lib/mailjet/resource.rb
@@ -311,7 +311,7 @@ module Mailjet
     def formatted_payload
       payload = attributes.reject { |k,v| v.blank? }
       if persisted?
-        payload = payload.slice(*resourceprop)
+        payload = payload.slice(*resourceprop.map(&:to_s))
       end
       payload = camelcase_keys(payload)
       payload.tap { |hs| hs.delete("Persisted") }


### PR DESCRIPTION
There is an issue with the `slice` method because it makes
payload empty `{}` because of the `resourceprop` items type.
Indeed, `attributes` contains string whereas `resourceprop`
contains symbols. Because of that the `slice` method doesn't
work as expected.

Details:
- CONVERT `resourceprop` to be an `Array<String>` in `formatted_payload`

Close #122 