### PR TITLE
Allow custom headers not starting with X- to be set

### DIFF
--- a/lib/mailjet/mailer.rb
+++ b/lib/mailjet/mailer.rb
@@ -45,7 +45,7 @@ class Mailjet::APIMailer
   HEADER_BLACKLIST = [
     'from', 'sender', 'subject', 'to', 'cc', 'bcc', 'return-path', 'delivered-to', 'dkim-signature',
     'domainkey-status', 'received-spf', 'authentication-results', 'received', 'user-agent', 'x-mailer',
-    'x-feedback-id', 'list-id', 'date', 'x-csa-complaints', 'message-id'
+    'x-feedback-id', 'list-id', 'date', 'x-csa-complaints', 'message-id', 'reply-to'
   ]
 
   def initialize(opts = {})

--- a/lib/mailjet/mailer.rb
+++ b/lib/mailjet/mailer.rb
@@ -42,6 +42,12 @@ class Mailjet::APIMailer
 
   CONNECTION_PERMITTED_OPTIONS = [:api_key, :secret_key]
 
+  HEADER_BLACKLIST = [
+    'from', 'sender', 'subject', 'to', 'cc', 'bcc', 'return-path', 'delivered-to', 'dkim-signature',
+    'domainkey-status', 'received-spf', 'authentication-results', 'received', 'user-agent', 'x-mailer',
+    'x-feedback-id', 'list-id', 'date', 'x-csa-complaints', 'message-id'
+  ]
+
   def initialize(opts = {})
     options = HashWithIndifferentAccess.new(opts)
 
@@ -110,7 +116,7 @@ class Mailjet::APIMailer
     if mail.header && mail.header.fields.any?
       content[:Headers] = {}
       mail.header.fields.each do |header|
-        if header.name.start_with?('X-') && !header.name.start_with?('X-MJ') && !header.name.start_with?('X-Mailjet')
+        if !header.name.start_with?('X-MJ') && !header.name.start_with?('X-Mailjet') && !HEADER_BLACKLIST.include?(header.name.downcase)
           content[:Headers][header.name] = header.value
         end
       end

--- a/lib/mailjet/mailer.rb
+++ b/lib/mailjet/mailer.rb
@@ -45,7 +45,8 @@ class Mailjet::APIMailer
   HEADER_BLACKLIST = [
     'from', 'sender', 'subject', 'to', 'cc', 'bcc', 'return-path', 'delivered-to', 'dkim-signature',
     'domainkey-status', 'received-spf', 'authentication-results', 'received', 'user-agent', 'x-mailer',
-    'x-feedback-id', 'list-id', 'date', 'x-csa-complaints', 'message-id', 'reply-to'
+    'x-feedback-id', 'list-id', 'date', 'x-csa-complaints', 'message-id', 'reply-to', 'content-type',
+    'mime-version', 'content-transfer-encoding'
   ]
 
   def initialize(opts = {})

--- a/spec/mailjet/mailer_spec.rb
+++ b/spec/mailjet/mailer_spec.rb
@@ -198,13 +198,13 @@ module Mailjet
       from_email = 'albert@bar.com'
       recipients = 'test <test@test.com>'
 
-      message = Mail.new
+      message = Mail.new(headers: {Key: 'value'})
       message.from = "#{from_name} <#{from_email}>"
       message.to = recipients
 
       expect(Mailjet::Send).to receive(:create).with(
         hash_including(
-          :Messages=>[{:To=>[{:Email=>"test@test.com", :Name=>"test"}], :Headers=>{}, :From=>{:Email=>"albert@bar.com", :Name=>"Albert"}}]
+          :Messages=>[{:To=>[{:Email=>"test@test.com", :Name=>"test"}], :Headers=>{'Key'=>"value"}, :From=>{:Email=>"albert@bar.com", :Name=>"Albert"}}]
         ),
         { "version" => "v3.1" }
       )


### PR DESCRIPTION
As mentioned in Issue #135, it's currently impossible to set custom email headers not starting with X-. This PR fixes this problem.