### PR TITLE
add instructions to override settings using ActionMailer callbacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,9 +10,11 @@ tmtags
 \#*
 .\#*
 
-
 ## VIM
 *.swp
+
+## INTELLIJ
+.idea
 
 ## PROJECT::GENERAL
 tags

--- a/README.md
+++ b/README.md
@@ -372,6 +372,43 @@ class AwesomeMailer < ApplicationMailer
 end
 ```
 
+You also can override default settings using [ActionMailer after callback](https://guides.rubyonrails.org/action_mailer_basics.html#action-mailer-callbacks):
+
+```ruby
+class ApplicationMailer < ActionMailer::Base
+  before_action :set_user
+  after_action  :override_mailjet_defaults
+
+  def awesome_mail
+    mail(to: @user.email)
+  end
+
+  private
+
+  def set_user
+    @user = params[:user]
+  end
+
+  def override_mailjet_defaults
+    mailjet_api_key    = params[:mailjet_api_key].presence
+    mailjet_secret_key = params[:mailjet_secret_key].presence
+
+    unless mailjet_api_key.nil? || mailjet_secret_key.nil?
+      mail.delivery_method.settings.merge!(
+        user_name: mailjet_api_key,
+        password:  mailjet_secret_key
+      )
+    end
+  end
+end
+
+# using default settings from initializer
+ApplicationMailer.with(user: user).awesome_email.deliver_now
+
+# temporary using other settings
+ApplicationMailer.with(user: user, mailjet_api_key: 'api_key', mailjet_secret_key: 'secret_key').awesome_email.deliver_now
+```
+
 Keep in mind that to use the latest version of the Send API, you need to specify the version via `delivery_method_options`:
 
 ```ruby


### PR DESCRIPTION
Note: This commit also includes an update of .gitignore file for IntelliJ IDEs users

I was looking for a solution to temporary override Mailjet credentials without having to specify `api_key` and `secret_key` params within `delivery_method_options` of all my mailers.
The idea of using callbacks is to keep the mailers very clean, but it requires to manually map Mailjet settings with raw `user_name` and `password` SMTP settings. 

I am wondering if this tip should be part of the README, but I wanted to share it to you.  
Please give me feedbacks if you think about a better integrated solution.