### PR TITLE
Fix for detailcontent of templates

### DIFF
--- a/lib/mailjet/connection.rb
+++ b/lib/mailjet/connection.rb
@@ -15,6 +15,8 @@ module Mailjet
       broken_url = url.split("/")
       if broken_url.include?("contactslist") && broken_url.include?("managemanycontacts") && broken_url.last.to_i > 0
         self.class.new(url, options[:user], options[:password], options)
+      elsif broken_url.include?("detailcontent")
+        self.class.new(url, options[:user], options[:password], options)
       else
         self.class.new(concat_urls(url, suburl), options[:user], options[:password], options)
       end

--- a/lib/mailjet/resource.rb
+++ b/lib/mailjet/resource.rb
@@ -34,9 +34,6 @@ module Mailjet
       end
 
       def self.default_connection(options = {})
-        p options[:url]
-        p options[:version]
-        p resource_path
         Mailjet::Connection.new(
           "#{options[:url]}/#{options[:version]}/#{resource_path}",
           options[:api_key] || Mailjet.config.api_key,

--- a/lib/mailjet/resource.rb
+++ b/lib/mailjet/resource.rb
@@ -34,6 +34,9 @@ module Mailjet
       end
 
       def self.default_connection(options = {})
+        p options[:url]
+        p options[:version]
+        p resource_path
         Mailjet::Connection.new(
           "#{options[:url]}/#{options[:version]}/#{resource_path}",
           options[:api_key] || Mailjet.config.api_key,

--- a/lib/mailjet/resources/template_detailcontent.rb
+++ b/lib/mailjet/resources/template_detailcontent.rb
@@ -4,8 +4,8 @@ module Mailjet
     self.action = 'detailcontent'
     self.resource_path = "REST/template/id/#{self.action}"
     self.public_operations = [:get,:post]
-    self.filters = [:api_key, :categories, :categories_selection_method, :edit_mode, :name, :owner_type, :purposes, :purposes_selection_method, :user]
-    self.resourceprop = [:author, :categories, :copyright, :description, :edit_mode, :is_starred, :name, :owner_type, :presets, :purposes]
+    self.filters = []
+    self.resourceprop = [:text_part, :html_part, :headers, :mjml_content]
 
   end
 end


### PR DESCRIPTION
This is a quick fix for fetching detailcontent of templates.

Surprisingly, fetching detailcontent for a campaigndraft works event without the change in connection.rb. I have not investigated why that is the case though.