### PR TITLE
DE-34 Add individual .find implementation

### DIFF
--- a/lib/mailjet/resources/contact_getcontactslists.rb
+++ b/lib/mailjet/resources/contact_getcontactslists.rb
@@ -6,5 +6,26 @@ module Mailjet
     self.public_operations = [:get]
     self.filters = []
     self.resourceprop = []
+
+    def self.find(id, job_id = nil, options = {})
+      opts = define_options(options)
+      self.resource_path = create_action_resource_path(id, job_id) if self.action
+
+      raw_data = parse_api_json(connection(opts)[id].get(default_headers))
+
+      if raw_data.count == 1
+        return instanciate_from_api(raw_data.first)
+      end
+
+      raw_data.map do |entity|
+        instanciate_from_api(entity)
+      end
+    rescue Mailjet::ApiError => e
+      if e.code == 404
+        nil
+      else
+        raise e
+      end
+    end
   end
 end


### PR DESCRIPTION
Add individual `.find` implementation to `Mailjet::Contact_getcontactslists`.
The method returns an object when API returns one object. Otherwise, the method returns a collection of objects.