### PR TITLE
Avoid loading ActionMailer early

### DIFF
--- a/lib/mailjet.rb
+++ b/lib/mailjet.rb
@@ -21,7 +21,7 @@ module Mailjet
   end
 end
 
-if defined?(ActionMailer)
+ActiveSupport.on_load(:action_mailer) do
   require 'action_mailer/version'
   require 'mailjet/mailer' if ActionMailer::Base.respond_to?(:add_delivery_method)
 end


### PR DESCRIPTION
Removes a "_DEPRECATION WARNING: Initialization autoloaded the constants ActionText::ContentHelper and ActionText::TagHelper._" warning when starting the Rails app.

Fix #213