### PR TITLE
Add public setter/getter for settings

### DIFF
--- a/lib/mailjet/mailer.rb
+++ b/lib/mailjet/mailer.rb
@@ -58,6 +58,13 @@ class Mailjet::APIMailer
     @connection_options = options.slice(*CONNECTION_PERMITTED_OPTIONS)
   end
 
+  def settings=(opts = {})
+    options = HashWithIndifferentAccess.new(opts)
+
+    @delivery_method_options_v3_0 = options.slice(*V3_0_PERMITTED_OPTIONS)
+    @delivery_method_options_v3_1 = options.slice(*V3_1_PERMITTED_OPTIONS)
+  end
+
   def deliver!(mail, opts = {})
     options = HashWithIndifferentAccess.new(opts)
 

--- a/lib/mailjet/mailer.rb
+++ b/lib/mailjet/mailer.rb
@@ -65,11 +65,8 @@ class Mailjet::APIMailer
     @delivery_method_options_v3_1 = options.slice(*V3_1_PERMITTED_OPTIONS)
   end
 
-  def settings
-    {
-      v3_0: @delivery_method_options_v3_0,
-      v3_1: @delivery_method_options_v3_1
-    }
+  def settings(version: Mailjet.config.api_version)
+    version == 'v3.1' ? @delivery_method_options_v3_1 : @delivery_method_options_v3_0
   end
 
   def deliver!(mail, opts = {})

--- a/lib/mailjet/mailer.rb
+++ b/lib/mailjet/mailer.rb
@@ -65,6 +65,13 @@ class Mailjet::APIMailer
     @delivery_method_options_v3_1 = options.slice(*V3_1_PERMITTED_OPTIONS)
   end
 
+  def settings
+    {
+      v3_0: @delivery_method_options_v3_0,
+      v3_1: @delivery_method_options_v3_1
+    }
+  end
+
   def deliver!(mail, opts = {})
     options = HashWithIndifferentAccess.new(opts)
 

--- a/lib/mailjet/mailer.rb
+++ b/lib/mailjet/mailer.rb
@@ -65,7 +65,7 @@ class Mailjet::APIMailer
     @delivery_method_options_v3_1 = options.slice(*V3_1_PERMITTED_OPTIONS)
   end
 
-  def settings(version: Mailjet.config.api_version)
+  def settings(version: @version || Mailjet.config.api_version)
     version == 'v3.1' ? @delivery_method_options_v3_1 : @delivery_method_options_v3_0
   end
 


### PR DESCRIPTION
The setter works as the initializer does, but the getter works based on the configured API version so that we can still intuitively change the delivery method settings as described in #219.

Closes #219 