### PR TITLE
Nil error fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ pkg
 .env
 .ruby-version
 gd_bundle-g2.crt
+
+Gemfile.lock

--- a/lib/mailjet/resource.rb
+++ b/lib/mailjet/resource.rb
@@ -28,6 +28,8 @@ module Mailjet
         cattr_accessor :resource_path, :public_operations, :read_only, :filters, :resourceprop, :read_only_attributes, :action, :non_json_urls, :version
         cattr_writer :connection
 
+        self.read_only_attributes = []
+
         def self.connection(options = {})
           class_variable_get(:@@connection) || default_connection(options)
         end

--- a/spec/mailjet/resource_spec.rb
+++ b/spec/mailjet/resource_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Mailjet::Resource do
           :accept_encoding => :deflate,
           :content_type => :json,
           :params => { "Limit" => 1 },
-          :user_agent => "mailjet-api-v3-ruby/1.7.0"
+          :user_agent => "mailjet-api-v3-ruby/#{Mailjet::VERSION}"
         }
       ).and_return('{"Data" : [{ "Test" : "Value" }]}')
     end
@@ -63,7 +63,7 @@ RSpec.describe Mailjet::Resource do
           :accept_encoding => :deflate,
           :content_type => :json,
           :params => {},
-          :user_agent => "mailjet-api-v3-ruby/1.7.0"
+          :user_agent => "mailjet-api-v3-ruby/#{Mailjet::VERSION}"
         }
       ).and_return('{"Data" : [{ "Test" : "Value1" }, { "Test" : "Value2" }]}')
     end
@@ -89,7 +89,7 @@ RSpec.describe Mailjet::Resource do
           :accept => :json,
           :accept_encoding => :deflate,
           :content_type => :json,
-          :user_agent => "mailjet-api-v3-ruby/1.7.0"
+          :user_agent => "mailjet-api-v3-ruby/#{Mailjet::VERSION}"
         }
       ).and_return("{\"Data\" : [{ \"ID\" : #{id}, \"Test\" : \"Value1\" }]}")
     end


### PR DESCRIPTION
I've been trying to do some API stuff with contactdata and keep receiving the following error:

```
NoMethodError: undefined method `map' for nil:NilClass

          .except(*read_only_attributes.map(&:to_s))
                                       ^^^^
from /Users/jnunemaker/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/mailjet-1.7.1/lib/mailjet/resource.rb:321:in `formatted_payload'
```

I traced the issue back to https://github.com/mailjet/mailjet-gem/pull/228/files#diff-30b8f3e8ee3693a89314a55208b3e614eeb74c614421803f68fc7e31c3d6aaf8R320, which adds a map call on the new class attribute. 

The issue is that for all resources that do not adjust the default value for `read_only_attributes` (all except contact), a nil no method error is received when map is called. 

This fixes that by defaulting `read_only_attributes` to an array so its `[].map` instead of `nil.map`. I considered doing a nil check instead of defaulting but defaulting to an array felt more "correct". 