### PR TITLE
Add ci task for github actions

### DIFF
--- a/.github/ci.yml
+++ b/.github/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby:
+          - 2.2
+          - 2.3
+          - 2.4
+          - 2.5
+          - 2.6
+          - 2.7
+          - '3.0' # Quoted, to avoid YAML float 3.0 interplated to "3"
+          - 3.1
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true # Run "bundle install", and cache the result automatically.
+      - name: Run Rake
+        run: bundle exec rake


### PR DESCRIPTION
The goal is to prevent failures from slipping into the code base. When I forked and worked on https://github.com/mailjet/mailjet-gem/pull/237, I found that the specs were failing locally that showed the bug even before I made the fix.

In order for this to work you will need to go to https://github.com/jnunemaker/mailjet-gem/settings/actions and enable github actions. If you have any questions, let me know.