### PR TITLE
Fixed issue with sending unmodified parameters

### DIFF
--- a/lib/mailjet/resources/contact.rb
+++ b/lib/mailjet/resources/contact.rb
@@ -5,20 +5,15 @@ module Mailjet
     self.public_operations = [:get, :put, :post]
     self.filters = [:campaign, :contacts_list, :is_unsubscribed, :last_activity_at, :recipient, :status]
     self.resourceprop = [
-      :created_at,
       :delivered_count,
       :email,
       :id,
       :is_opt_in_pending,
       :is_spam_complaining,
-      :last_activity_at,
-      :last_update_at,
       :name,
-      :unsubscribed_at,
       :unsubscribed_by,
       :is_excluded_from_campaigns
     ]
     self.read_only_attributes = [:created_at, :last_activity_at, :last_update_at, :unsubscribed_at]
-
   end
 end

--- a/lib/mailjet/resources/listrecipient.rb
+++ b/lib/mailjet/resources/listrecipient.rb
@@ -4,7 +4,8 @@ module Mailjet
     self.resource_path = 'REST/listrecipient'
     self.public_operations = [:get, :put, :post, :delete]
     self.filters = [:active, :blocked, :contact, :contact_email, :contacts_list, :last_activity_at, :list_name, :opened, :status, :unsub]
-    self.resourceprop = [:contact, :id, :is_active, :is_unsubscribed, :list, :unsubscribed_at, :contact_id, :list_id, 'ContactID', 'ListID', 'ContactALT', 'ListALT']
+    self.resourceprop = [:contact, :id, :is_active, :is_unsubscribed, :list, :contact_id, :list_id, 'ContactID', 'ListID', 'ContactALT', 'ListALT']
 
+    self.read_only_attributes = [:subscribed_at, :unsubscribed_at]
   end
 end

--- a/lib/mailjet/version.rb
+++ b/lib/mailjet/version.rb
@@ -1,3 +1,3 @@
 module Mailjet
-  VERSION = "1.7.10"
+  VERSION = "1.7.11"
 end


### PR DESCRIPTION
attempt to subscribe a contact via

PUT   https://api.mailjet.com/v3/REST/listrecipient/{listrecipient_ID}

the call goes through without issues. But when try to unsubscribe a contact, by switching IsUnsubscribed to false, get:

401 Unauthorized - Invalid Domain or API key: Internal error: MJ19 Setting a value for property "UnsubscribedAt" is not allowed (Mailjet::Unauthorized)